### PR TITLE
Improve console log helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+composer.lock
+

--- a/README.md
+++ b/README.md
@@ -10,25 +10,34 @@ Laravel package to log messages to the browser console with style!
     composer require emsici/console-log:dev-main
     ```
 
-2. Add the service provider to your `config/app.php` file:
+2. The service providers are auto-discovered. If you have disabled package discovery, add the providers to your `config/app.php` file:
 
     ```php
     'providers' => [
         // Other Service Providers
-
-        ARCyberLab\ConsoleLog\ConsoleLogServiceProvider::class,
+        emsici\ConsoleLog\ConsoleLogServiceProvider::class,
+        emsici\ConsoleLog\ConsoleLogBladeServiceProvider::class,
     ],
     ```
 
-
 ## Usage
 
-To log messages to the browser console with style, use the `ConsoleLog::log` method in your Livewire components:
+Log styled messages to the browser console from your Livewire components:
 
 ```php
-use ARCyberLab\ConsoleLog\ConsoleLog;
+use emsici\ConsoleLog\ConsoleLog;
 
 ConsoleLog::log(
-    ['Message 1', 'color: red; font-weight: bold;'], 
+    ['Message 1', 'color: red; font-weight: bold;'],
     ['Message 2', 'color: blue;']
 );
+```
+
+Include the Blade directive in your layout to load the required script:
+
+```blade
+@LivewireConsoleLog
+```
+
+This directive registers a listener that outputs the messages in the browser console with the provided styles.
+

--- a/resources/views/console-log.blade.php
+++ b/resources/views/console-log.blade.php
@@ -1,22 +1,9 @@
 <script>
-        document.addEventListener('livewire:load', function () {
-            Livewire.on('LivewireConsoleLog', (event) => {
-                let messages = event.detail.messages;
-                messages.forEach((message) => {
-                    let logMessage = "";
-                    let logStyles = [];
-
-                    if (Array.isArray(message)) {
-                        message.forEach((part) => {
-                            logMessage += `%c${part[0].text} `;
-                            logStyles.push(part[0].style);
-                        });
-
-                        console.log(logMessage.trim(), ...logStyles);
-                    } else {
-                        console.log('Message format is incorrect');
-                    }
-                });
+    document.addEventListener('livewire:load', () => {
+        Livewire.on('LivewireConsoleLog', ({ messages }) => {
+            messages.forEach(([text, style]) => {
+                console.log(`%c${text}`, style ?? '');
             });
         });
-    </script>
+    });
+</script>

--- a/src/ConsoleLog.php
+++ b/src/ConsoleLog.php
@@ -6,13 +6,9 @@ use Livewire\Component;
 
 class ConsoleLog extends Component
 {
-    public static function send(array ...$messages)
+    public static function log(array ...$messages): void
     {
-        // Instanțierea unui obiect al clasei
         $instance = app(static::class);
-
-        foreach ($messages as $message) {
-            $instance->dispatch('LivewireConsoleLog', ['messages' => $message]);
-        }
+        $instance->dispatch('LivewireConsoleLog', ['messages' => $messages]);
     }
 }


### PR DESCRIPTION
## Summary
- Dispatch all console messages in one Livewire event
- Simplify JavaScript listener and document usage
- Add basic .gitignore for vendor and lock file

## Testing
- `composer install | tail -n 20`
- `php -l src/ConsoleLog.php`
- `php -l src/ConsoleLogBladeServiceProvider.php src/ConsoleLogServiceProvider.php`
