### PR TITLE
Improve console log helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+composer.lock
+

--- a/README.md
+++ b/README.md
@@ -7,28 +7,40 @@ Laravel package to log messages to the browser console with style!
 1. Add the package to your Laravel project:
 
     ```bash
-    composer require emsici/console-log:dev-main
+    composer require emsici/console-log
     ```
 
-2. Add the service provider to your `config/app.php` file:
+2. The service providers are auto-discovered. If you have disabled package discovery, add the providers to your `config/app.php` file:
 
     ```php
     'providers' => [
         // Other Service Providers
-
-        ARCyberLab\ConsoleLog\ConsoleLogServiceProvider::class,
+        Emsici\ConsoleLog\ConsoleLogServiceProvider::class,
+        Emsici\ConsoleLog\ConsoleLogBladeServiceProvider::class,
     ],
     ```
 
-
 ## Usage
 
-To log messages to the browser console with style, use the `ConsoleLog::log` method in your Livewire components:
+Log messages to the browser console from anywhere in your application. Messages can be plain strings or include style information:
 
 ```php
-use ARCyberLab\ConsoleLog\ConsoleLog;
+use Emsici\ConsoleLog\ConsoleLog;
 
 ConsoleLog::log(
-    ['Message 1', 'color: red; font-weight: bold;'], 
-    ['Message 2', 'color: blue;']
+    'Saved successfully',
+    ['Warning', 'color: red; font-weight: bold;']
 );
+
+// Optional: scope dispatch to a specific Livewire component instance
+ConsoleLog::log($this, 'Scoped to this component');
+```
+
+Include the Blade directive in your layout to load the required script:
+
+```blade
+@consoleLog {{-- or @LivewireConsoleLog for backwards compatibility --}}
+```
+
+This directive registers a listener that outputs the messages in the browser console with optional styles.
+

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     },
     "autoload": {
         "psr-4": {
-            "emsici\\ConsoleLog\\": "src/"
+            "Emsici\\ConsoleLog\\": "src/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "emsici\\ConsoleLog\\ConsoleLogServiceProvider",
-                "emsici\\ConsoleLog\\ConsoleLogBladeServiceProvider"
+                "Emsici\\ConsoleLog\\ConsoleLogServiceProvider",
+                "Emsici\\ConsoleLog\\ConsoleLogBladeServiceProvider"
             ]
         }
     }

--- a/resources/views/console-log.blade.php
+++ b/resources/views/console-log.blade.php
@@ -1,22 +1,17 @@
 <script>
-        document.addEventListener('livewire:load', function () {
-            Livewire.on('LivewireConsoleLog', (event) => {
-                let messages = event.detail.messages;
-                messages.forEach((message) => {
-                    let logMessage = "";
-                    let logStyles = [];
-
-                    if (Array.isArray(message)) {
-                        message.forEach((part) => {
-                            logMessage += `%c${part[0].text} `;
-                            logStyles.push(part[0].style);
-                        });
-
-                        console.log(logMessage.trim(), ...logStyles);
-                    } else {
-                        console.log('Message format is incorrect');
-                    }
-                });
+    document.addEventListener('livewire:load', () => {
+        const handle = ({ messages }) => {
+            messages.forEach(message => {
+                if (Array.isArray(message)) {
+                    const [text, style] = message;
+                    console.log(`%c${text}`, style ?? '');
+                } else {
+                    console.log(message);
+                }
             });
-        });
-    </script>
+        };
+
+        Livewire.on('LivewireConsoleLog', handle);
+        Livewire.on('console-log', handle);
+    });
+</script>

--- a/src/ConsoleLog.php
+++ b/src/ConsoleLog.php
@@ -1,18 +1,34 @@
 <?php
 
-namespace emsici\ConsoleLog;
+namespace Emsici\ConsoleLog;
 
 use Livewire\Component;
+use Livewire\Livewire;
 
-class ConsoleLog extends Component
+class ConsoleLog
 {
-    public static function send(array ...$messages)
+    /**
+     * Dispatch messages to the browser console.
+     *
+     * Messages may be plain strings or an array of [message, style].
+     * Pass a Livewire component instance as the first argument to dispatch
+     * within that component's context; otherwise a global dispatch will be
+     * triggered allowing usage outside of components.
+     */
+    public static function log(...$arguments): void
     {
-        // Instanțierea unui obiect al clasei
-        $instance = app(static::class);
+        $component = null;
 
-        foreach ($messages as $message) {
-            $instance->dispatch('LivewireConsoleLog', ['messages' => $message]);
+        if ($arguments && $arguments[0] instanceof Component) {
+            $component = array_shift($arguments);
+        }
+
+        $payload = ['messages' => $arguments];
+
+        if ($component) {
+            $component->dispatch('LivewireConsoleLog', $payload);
+        } else {
+            Livewire::dispatch('LivewireConsoleLog', $payload);
         }
     }
 }

--- a/src/ConsoleLogBladeServiceProvider.php
+++ b/src/ConsoleLogBladeServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace emsici\ConsoleLog;
+namespace Emsici\ConsoleLog;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Blade;
@@ -9,6 +9,11 @@ class ConsoleLogBladeServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+        Blade::directive('consoleLog', function () {
+            return "<?php echo view('console-log::console-log'); ?>";
+        });
+
+        // Backwards compatibility for the old directive name
         Blade::directive('LivewireConsoleLog', function () {
             return "<?php echo view('console-log::console-log'); ?>";
         });

--- a/src/ConsoleLogServiceProvider.php
+++ b/src/ConsoleLogServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace emsici\ConsoleLog;
+namespace Emsici\ConsoleLog;
 
 use Illuminate\Support\ServiceProvider;
 


### PR DESCRIPTION
## Summary
- allow `ConsoleLog::log` to dispatch globally when no component is provided
- browser listener handles both `LivewireConsoleLog` and new `console-log` events
- document usage from anywhere with optional component scoping

## Testing
- `composer install >/tmp/composer.log && tail -n 20 /tmp/composer.log`
- `php -l src/ConsoleLog.php`
- `php -l src/ConsoleLogBladeServiceProvider.php src/ConsoleLogServiceProvider.php`


------
https://chatgpt.com/codex/tasks/task_e_68b43760c6e08321a9781b6a647f4ee7